### PR TITLE
Recursive components

### DIFF
--- a/browser/DocumentRenderer.js
+++ b/browser/DocumentRenderer.js
@@ -297,6 +297,10 @@ class DocumentRenderer {
         return;
       }
 
+      if (componentContext.recursive) {
+        componentContext = parentContext;
+      }
+
       this._localContextRegistry[componentId] = componentContext;
       return contextToDescriptor(componentContext);
     }

--- a/lib/streams/ComponentReadable.js
+++ b/lib/streams/ComponentReadable.js
@@ -103,7 +103,15 @@ class ComponentReadable extends Readable {
       var descriptor = this._localContextRegistry[parentComponent]
         .find((descriptor) => descriptor.name === this._currentComponent);
 
-      component = transformDescriptorToComponent(descriptor);
+      if (!descriptor) {
+        return null;
+      }
+
+      if (descriptor.recursive) {
+        component = transformDescriptorToComponent(this._localContextRegistry[parentComponent]);
+      } else {
+        component = transformDescriptorToComponent(descriptor);
+      }
     }
 
     if (!component) {

--- a/lib/streams/ComponentReadable.js
+++ b/lib/streams/ComponentReadable.js
@@ -27,6 +27,7 @@ class ComponentReadable extends Readable {
     this._context = context;
     this._tokenQueue = [];
     this._localContextRegistry = {};
+    this._rendereredComponentsList = {};
     this._processingFoundTagPromise = null;
     this._delayedHTML = '';
     this._isFlushed = false;
@@ -108,7 +109,7 @@ class ComponentReadable extends Readable {
       }
 
       if (descriptor.recursive) {
-        component = transformDescriptorToComponent(this._localContextRegistry[parentComponent]);
+        component = this._rendereredComponentsList[parentComponent];
       } else {
         component = transformDescriptorToComponent(descriptor);
       }
@@ -119,6 +120,7 @@ class ComponentReadable extends Readable {
     }
 
     // Save local context for current component
+    this._rendereredComponentsList[this._currentComponent] = component;
     this._localContextRegistry[this._currentComponent] = component.children || [];
 
     var componentContext = Object.create(this._context);

--- a/test/lib/DocumentRenderer.js
+++ b/test/lib/DocumentRenderer.js
@@ -1364,10 +1364,20 @@ lab.experiment('lib/DocumentRenderer', () => {
 
     documentRenderer.render(routingContext);
 
+    var expected = `
+        <!DOCTYPE html>
+        <html>
+          <head></head>
+        <body>
+          <cat-recursive id="1"><cat-recursive id="2"><cat-recursive id="3"><cat-recursive id="4"><cat-recursive id="5"><cat-recursive id="6"><cat-recursive id="7"><cat-recursive id="8"><cat-recursive id="9"><cat-recursive id="10">undefined</cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive></cat-recursive>
+        </body>
+        </html>
+      `;
+
     routingContext.middleware.response
       .on('error', done)
       .on('finish', () => {
-        assert.strictEqual(routingContext.middleware.response.result, html, 'Wrong HTML');
+        assert.strictEqual(routingContext.middleware.response.result, expected, 'Wrong HTML');
         done();
       });
   });

--- a/test/lib/DocumentRenderer.js
+++ b/test/lib/DocumentRenderer.js
@@ -1319,14 +1319,22 @@ lab.experiment('lib/DocumentRenderer', () => {
 
         return `<cat-recursive id="${ctx.id}"></cat-recursive>`;
       }
+
+      render () {
+        return {
+          id: Number(this.$context.attributes['id']) + 1
+        };
+      }
     }
 
     var recursive = {
       constructor: Recursive,
-      children: {
-        name: 'recursive',
-        recursive: true
-      }
+      children: [
+        {
+          name: 'recursive',
+          recursive: true
+        }
+      ]
     };
 
     class Document {


### PR DESCRIPTION
New option in children: 
```
module.exports = {
  constructor: Parent,
  children: [
    {
       name: "recursive",
       recursive: true
    }
  ]
}
```

Allow use parent context, instead of write own. Actual for recursive components. Be care about recursion exit.