### PR TITLE
fix compatibility with Firerfox

### DIFF
--- a/browser/DocumentRenderer.js
+++ b/browser/DocumentRenderer.js
@@ -851,7 +851,7 @@ function createCustomEvent (event, currentTargetGetter) {
   const keys = [];
   const properties = {};
 
-  for (const key in event) {
+  for (let key in event) {
     keys.push(key);
   }
 


### PR DESCRIPTION
Firefox does not yet allow to use `const` keyword in `for..of` loops.
This fixes the compatibility with Firefox