### PR TITLE
Slot rendering inside morphdom loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "baobab": "^2.3.3",
     "browser-process-hrtime": "^0.1.2",
     "entities": "^1.1.1",
-    "morphdom": "^1.3.0",
+    "morphdom": "^2.0.4",
     "pretty-hrtime": "^1.0.2",
     "uuid": "^2.0.2"
   },


### PR DESCRIPTION
Current version do minimum 3 loops inside `renderCompoent()`.

1) Collect component childNodes
2) Morphdom loop
3) Morph slot loop

This version use morphdom hooks (update/add element) for 1 and 3 operations.
Also this commit fix broken slot updates.