### PR TITLE
Collect garbage only when all components updated

### DIFF
--- a/browser/DocumentRenderer.js
+++ b/browser/DocumentRenderer.js
@@ -298,8 +298,7 @@ class DocumentRenderer {
         .catch(reason => this._eventBus.emit('error', reason));
     };
 
-    return this._traverseComponentsWithContext([rootElement], action, rootContext)
-      .then(() => this._collectRenderingGarbage(renderingContext));
+    return this._traverseComponentsWithContext([rootElement], action, rootContext);
   }
 
   /**
@@ -960,6 +959,7 @@ class DocumentRenderer {
 
     return Promise.all(promises)
       .catch(reason => this._eventBus.emit('error', reason))
+      .then(() => this._collectRenderingGarbage(renderingContext))
       .then(() => {
         this._isUpdating = false;
       });


### PR DESCRIPTION
Move `_collectRenderingGarbage` to `_updateComponents`.
We should not collect garbage during every component rendering, because component tree are not ready for cleanup, also we should not collect garbage at `createComponent` step.